### PR TITLE
Support non capture grouping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ getRegExp('ㅊㅅ퀴즈', {  // /[ㅊ차-칳].*[ㅅ사-싷].*퀴.*[즈-즿]/i
   initialSearch: true,
   fuzzy: true,
 });
-getRegExp('ㅊㅅ퀴즈', {  // /한글(?:날|나[라-맇])/i
+getRegExp('한글날', {  // /한글(?:날|나[라-맇])/i
   nonCaptureGroup: true
 });
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ getRegExp('ㅊㅅ퀴즈', {  // /[ㅊ차-칳].*[ㅅ사-싷].*퀴.*[즈-즿]/i
   initialSearch: true,
   fuzzy: true,
 });
+getRegExp('ㅊㅅ퀴즈', {  // /한글(?:날|나[라-맇])/i
+  nonCaptureGroup: true
+});
 
 engToKor('gksrmfskf');  // 한글날
 engToKor('Rkrenrl, xhdekfr');  // 깍두기, 통닭

--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -54,7 +54,7 @@ describe('options.endsWith', () => {
 
 describe('options.ignoreSpace', () => {
   test('ignoreSpace: false (default)', () => {
-    expect(getRegExp('한글날').source).toBe(getRegExp('한글날').source);
+    expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
     expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
   });
   test('ignoreSpace: true', () => {

--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -54,7 +54,7 @@ describe('options.endsWith', () => {
 
 describe('options.ignoreSpace', () => {
   test('ignoreSpace: false (default)', () => {
-    expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
+    expect(getRegExp('한글날').source).toBe(getRegExp('한글날').source);
     expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
   });
   test('ignoreSpace: true', () => {
@@ -79,6 +79,16 @@ describe('options.global', () => {
   });
   test('global: true', () => {
     expect(getRegExp('ㅎㄱ', { global: true }).toString()).toBe('/ㅎ[ㄱ가-깋]/gi');
+  });
+});
+
+describe('options.nonCaptureGroup', () => {
+  test('ignoreSpace: false (default)', () => {
+    expect(getRegExp('한글날').source).toBe(getRegExp('한글날').source);
+    expect(getRegExp('한글날').source).toBe('한글(날|나[라-맇])');
+  });
+  test('ignoreSpace: true', () => {
+    expect(getRegExp('한글날', { nonCaptureGroup: true }).source).toBe('한글(?:날|나[라-맇])');
   });
 });
 

--- a/src/getRegExp.ts
+++ b/src/getRegExp.ts
@@ -19,12 +19,16 @@ interface GetRegExpOptions {
   ignoreCase?: boolean;
   global?: boolean;
   fuzzy?: boolean;
+  nonCaptureGroup?: boolean;
 }
 
 const FUZZY = `__${parseInt('fuzzy', 36)}__`;
 const IGNORE_SPACE = `__${parseInt('ignorespace', 36)}__`;
 
-function getRegExp(search: string, { initialSearch = false, startsWith = false, endsWith = false, ignoreSpace = false, ignoreCase = true, global = false, fuzzy = false }: GetRegExpOptions = {}) {
+function getRegExp(
+  search: string,
+  { initialSearch = false, startsWith = false, endsWith = false, ignoreSpace = false, ignoreCase = true, global = false, fuzzy = false, nonCaptureGroup = false }: GetRegExpOptions = {},
+) {
   let frontChars = search.split('');
   let lastChar = frontChars.slice(-1)[0];
   let lastCharPattern = '';
@@ -81,7 +85,7 @@ function getRegExp(search: string, { initialSearch = false, startsWith = false, 
         break;
     }
 
-    lastCharPattern = patterns.length > 1 ? `(${patterns.join('|')})` : patterns[0];
+    lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
   }
   const glue = fuzzy ? FUZZY : ignoreSpace ? IGNORE_SPACE : '';
   const frontCharsPattern = initialSearch


### PR DESCRIPTION
- Add non capture group option

# AS-IS
```
'텍스트'.split(getRegExp('텍')) // ['어떠한 ', '텍', '텍', '스트']
```

# TO-BE
```
'텍스트'.split(getRegExp('텍', { nonCaptureGroup: true })) // ['어떠한 ', '텍', '스트']
```