### PR TITLE
getRegExp engToKor 옵션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "korean-regexp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": {
     "name": "Sung Won Cha",
     "email": "mygenie3@naver.com"
@@ -23,10 +23,10 @@
     "@types/jest": "^26.0.15",
     "jest": "^26.6.3",
     "prettier": "^2.2.0",
-    "rollup": "^2.33.3",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup": "^2.39.0",
+    "rollup-plugin-typescript2": "^0.31.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "typescript": "^4.9.4"
   },
   "scripts": {
     "prestart": "rm -rf dist/*",

--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -106,3 +106,22 @@ describe('options.fuzzy', () => {
     expect(matched).toMatchObject(['카페', '카카오페이', '카페오레', '아카펠라']);
   });
 });
+
+describe('options.engToKor', () => {
+  test('engToKor: false (default)', () => {
+    const pattern = getRegExp('gksr', { engToKor: false });
+    const words = ['gksr', '한글', '한국', '대한민국'];
+    const matched = words.filter((word) => word.match(pattern));
+    expect(matched).toMatchObject(['gksr']);
+  });
+  test('engToKor: true', () => {
+    const pattern = getRegExp('gksr', { engToKor: true });
+    const words = ['gksr', '한글', '한국', '대한민국'];
+    const matched = words.filter((word) => word.match(pattern));
+    expect(matched).toMatchObject(['gksr', '한글', '한국']);
+  });
+  test('engToKor: true (valid / invalid korean pattern)', () => {
+    expect(getRegExp('gksr', { engToKor: true }).source).toBe('(gksr)|(한[ㄱ가-깋])');
+    expect(getRegExp('korea', { engToKor: true }).source).toBe('korea');
+  });
+});

--- a/src/getRegExp.ts
+++ b/src/getRegExp.ts
@@ -1,4 +1,5 @@
 import { BASE, INITIALS, MEDIALS, FINALES, MIXED, MEDIAL_RANGE } from './constant';
+import engToKor from './engToKor';
 import escapeRegExp from './escapeRegExp';
 import getPhonemes from './getPhonemes';
 
@@ -20,82 +21,114 @@ interface GetRegExpOptions {
   global?: boolean;
   fuzzy?: boolean;
   nonCaptureGroup?: boolean;
+  engToKor?: boolean;
 }
 
 const FUZZY = `__${parseInt('fuzzy', 36)}__`;
 const IGNORE_SPACE = `__${parseInt('ignorespace', 36)}__`;
 
-function getRegExp(
-  search: string,
-  { initialSearch = false, startsWith = false, endsWith = false, ignoreSpace = false, ignoreCase = true, global = false, fuzzy = false, nonCaptureGroup = false }: GetRegExpOptions = {},
-) {
-  let frontChars = search.split('');
-  let lastChar = frontChars.slice(-1)[0];
-  let lastCharPattern = '';
+const getRegExp = (() => {
+  let lastSearch: string;
+  let lastPattern: RegExp;
 
-  const phonemes = getPhonemes(lastChar || '');
-
-  // 마지막 글자가 한글인 경우만 수행
-  if (phonemes.initialOffset !== -1) {
-    frontChars = frontChars.slice(0, -1);
-    const { initial, medial, finale, initialOffset, medialOffset } = phonemes;
-
-    // 해당 초성으로 시작하는 첫번째 문자 : 가, 나, 다, ... , 하
-    const baseCode = initialOffset * MEDIALS.length * FINALES.length + BASE;
-
-    const patterns = [];
-    switch (true) {
-      // case 1: 종성으로 끝나는 경우 (받침이 있는 경우)
-      case finale !== '': {
-        // 마지막 글자
-        patterns.push(lastChar);
-        // 종성이 초성으로 사용 가능한 경우
-        if (INITIALS.includes(finale)) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
-        }
-        // 종성이 복합 자음인 경우, 두 개의 자음으로 분리하여 각각 받침과 초성으로 사용
-        if (MIXED[finale]) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
-        }
-        break;
-      }
-
-      // case 2: 중성으로 끝나는 경우 (받침이 없는 경우)
-      case medial !== '': {
-        let from: number, to: number;
-        // 중성이 복합 모음인 경우 범위를 확장하여 적용
-        if (MEDIAL_RANGE[medial]) {
-          from = baseCode + MEDIALS.join('').search(MEDIAL_RANGE[medial][0]) * FINALES.length;
-          to = baseCode + MEDIALS.join('').search(MEDIAL_RANGE[medial][1]) * FINALES.length + FINALES.length - 1;
-        } else {
-          from = baseCode + medialOffset * FINALES.length;
-          to = from + FINALES.length - 1;
-        }
-        patterns.push(`[${String.fromCharCode(from)}-${String.fromCharCode(to)}]`);
-        break;
-      }
-
-      // case 3: 초성만 입력된 경우
-      case initial !== '': {
-        patterns.push(getInitialSearchRegExp(initial, true));
-        break;
-      }
-
-      default:
-        break;
+  return (
+    search: string,
+    {
+      initialSearch = false,
+      startsWith = false,
+      endsWith = false,
+      ignoreSpace = false,
+      ignoreCase = true,
+      global = false,
+      fuzzy = false,
+      nonCaptureGroup = false,
+      engToKor: _engToKor = false,
+    }: GetRegExpOptions = {},
+  ) => {
+    if (lastSearch === search) {
+      return lastPattern;
     }
+    let _search = search;
+    let additionalPatterns: string[] = [];
+    if (_engToKor && search.trim().match(/^([a-zA-Z0-9\s]{2,})$/)) {
+      const kor = engToKor(search.trim());
+      if (kor.match(/^[가-힣ㄱ-ㅎ0-9]/)) {
+        _search = kor;
+        additionalPatterns.push(escapeRegExp(search.trim()));
+      }
+    }
+    let frontChars = _search.split('');
+    let lastChar = frontChars.slice(-1)[0];
+    let lastCharPattern = '';
+
+    const phonemes = getPhonemes(lastChar || '');
+
+    // 마지막 글자가 한글인 경우만 수행
+    if (phonemes.initialOffset !== -1) {
+      frontChars = frontChars.slice(0, -1);
+      const { initial, medial, finale, initialOffset, medialOffset } = phonemes;
+
+      // 해당 초성으로 시작하는 첫번째 문자 : 가, 나, 다, ... , 하
+      const baseCode = initialOffset * MEDIALS.length * FINALES.length + BASE;
+
+      const patterns = [];
+      switch (true) {
+        // case 1: 종성으로 끝나는 경우 (받침이 있는 경우)
+        case finale !== '': {
+          // 마지막 글자
+          patterns.push(lastChar);
+          // 종성이 초성으로 사용 가능한 경우
+          if (INITIALS.includes(finale)) {
+          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
+          }
+          // 종성이 복합 자음인 경우, 두 개의 자음으로 분리하여 각각 받침과 초성으로 사용
+          if (MIXED[finale]) {
+          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
+          }
+          break;
+        }
+
+        // case 2: 중성으로 끝나는 경우 (받침이 없는 경우)
+        case medial !== '': {
+          let from: number, to: number;
+          // 중성이 복합 모음인 경우 범위를 확장하여 적용
+          if (MEDIAL_RANGE[medial]) {
+            from = baseCode + MEDIALS.join('').search(MEDIAL_RANGE[medial][0]) * FINALES.length;
+            to = baseCode + MEDIALS.join('').search(MEDIAL_RANGE[medial][1]) * FINALES.length + FINALES.length - 1;
+          } else {
+            from = baseCode + medialOffset * FINALES.length;
+            to = from + FINALES.length - 1;
+          }
+          patterns.push(`[${String.fromCharCode(from)}-${String.fromCharCode(to)}]`);
+          break;
+        }
+
+        // case 3: 초성만 입력된 경우
+        case initial !== '': {
+          patterns.push(getInitialSearchRegExp(initial, true));
+          break;
+        }
+
+        default:
+          break;
+      }
 
     lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
-  }
-  const glue = fuzzy ? FUZZY : ignoreSpace ? IGNORE_SPACE : '';
-  const frontCharsPattern = initialSearch
+    }
+    const glue = fuzzy ? FUZZY : ignoreSpace ? IGNORE_SPACE : '';
+    const frontCharsPattern = initialSearch
     ? frontChars.map((char) => (char.search(/[ㄱ-ㅎ]/) !== -1 ? getInitialSearchRegExp(char, true) : escapeRegExp(char))).join(glue)
-    : escapeRegExp(frontChars.join(glue));
-  let pattern = (startsWith ? '^' : '') + frontCharsPattern + glue + lastCharPattern + (endsWith ? '$' : '');
-  if (glue) {
-    pattern = pattern.replace(RegExp(FUZZY, 'g'), '.*').replace(RegExp(IGNORE_SPACE, 'g'), '\\s*');
-  }
-  return RegExp(pattern, (global ? 'g' : '') + (ignoreCase ? 'i' : ''));
-}
+      : escapeRegExp(frontChars.join(glue));
+    let pattern = (startsWith ? '^' : '') + frontCharsPattern + glue + lastCharPattern + (endsWith ? '$' : '');
+    if (glue) {
+      pattern = pattern.replace(RegExp(FUZZY, 'g'), '.*').replace(RegExp(IGNORE_SPACE, 'g'), '\\s*');
+    }
+    if (additionalPatterns.length > 0) {
+      pattern = [...additionalPatterns, pattern].map((e) => `(${e})`).join('|');
+    }
+    lastPattern = RegExp(pattern, (global ? 'g' : '') + (ignoreCase ? 'i' : ''));
+    return lastPattern;
+  };
+})();
 
 export default getRegExp;


### PR DESCRIPTION
https://github.com/bluewings/korean-regexp/issues/8

- [x] 영타 상태로 입력하는 경우에도 한글 정규식을 제공할 수 있는 기능 제공
- [x] 마지막 변환한 입력값과 동일한 입력값을 사용한 경우 기존의 정규식을 그대로 반환
  동일한 입력값에 대해서 배열을 순회하면서 함수 내부에서 getRegExp 를 호출하는 경우 불필요한 연산이 수행되는 문제
  
---

테스트 케이스 참고

https://github.com/bluewings/korean-regexp/blob/4904b0cb9e908d0ddc143f95901bf3a66385d6b2/src/getRegExp.test.ts#L111-L126