### PR TITLE
fix. 영문일 때 ignoreSpace 옵션에 대한 동작 수정

### DIFF
--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -60,6 +60,9 @@ describe('options.ignoreSpace', () => {
   test('ignoreSpace: true', () => {
     expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
   });
+  test('ignoreSpace: true', () => {
+    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
+  });
 });
 
 describe('options.ignoreCase', () => {

--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -56,14 +56,10 @@ describe('options.ignoreSpace', () => {
   test('ignoreSpace: false (default)', () => {
     expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
     expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
-  });
-  test('ignoreSpace: false', () => {
     expect(getRegExp('keyword', { ignoreSpace: false }).source).toBe('keyword');
   });
   test('ignoreSpace: true', () => {
     expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
-  });
-  test('ignoreSpace: true', () => {
     expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
   });
 });

--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -57,6 +57,9 @@ describe('options.ignoreSpace', () => {
     expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
     expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
   });
+  test('ignoreSpace: false', () => {
+    expect(getRegExp('keyword', { ignoreSpace: false }).source).toBe('keyword');
+  });
   test('ignoreSpace: true', () => {
     expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
   });

--- a/src/getRegExp.ts
+++ b/src/getRegExp.ts
@@ -79,11 +79,11 @@ const getRegExp = (() => {
           patterns.push(lastChar);
           // 종성이 초성으로 사용 가능한 경우
           if (INITIALS.includes(finale)) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
+            patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
           }
           // 종성이 복합 자음인 경우, 두 개의 자음으로 분리하여 각각 받침과 초성으로 사용
           if (MIXED[finale]) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
+            patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
           }
           break;
         }
@@ -113,13 +113,20 @@ const getRegExp = (() => {
           break;
       }
 
-    lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
+      lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
     }
     const glue = fuzzy ? FUZZY : ignoreSpace ? IGNORE_SPACE : '';
     const frontCharsPattern = initialSearch
-    ? frontChars.map((char) => (char.search(/[ㄱ-ㅎ]/) !== -1 ? getInitialSearchRegExp(char, true) : escapeRegExp(char))).join(glue)
+      ? frontChars.map((char) => (char.search(/[ㄱ-ㅎ]/) !== -1 ? getInitialSearchRegExp(char, true) : escapeRegExp(char))).join(glue)
       : escapeRegExp(frontChars.join(glue));
-    let pattern = (startsWith ? '^' : '') + frontCharsPattern + glue + lastCharPattern + (endsWith ? '$' : '');
+
+    let pattern = (startsWith ? '^' : '') + frontCharsPattern;
+    if (lastCharPattern.trim() === '') {
+      pattern = pattern + (endsWith ? '$' : '');
+    } else {
+      pattern = pattern + glue + lastCharPattern + (endsWith ? '$' : '');
+    }
+
     if (glue) {
       pattern = pattern.replace(RegExp(FUZZY, 'g'), '.*').replace(RegExp(IGNORE_SPACE, 'g'), '\\s*');
     }


### PR DESCRIPTION
# AS-IS
- 마지막 문자에도 `\\s*` 가 들어감
- `test k eyw ord   ` 라고 입력 되었을 때에 `k eyw ord` 만 잡고 싶은데 `k eyw ord   ` 까지 잡힘

```
  test('ignoreSpace: true', () => {
    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d\\s*');
  });
```

# TO-BE
- 한글인 경우에는 마지막에 `\\s*`  들어가지 않아서 이를 통일하도록 함
```
  test('ignoreSpace: true', () => {
    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
  });
```