### PR TITLE
fix. front, last pattern 이 있을 때에만 \s 추가하도록 수정

### DIFF
--- a/src/getRegExp.test.ts
+++ b/src/getRegExp.test.ts
@@ -56,9 +56,15 @@ describe('options.ignoreSpace', () => {
   test('ignoreSpace: false (default)', () => {
     expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
     expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
+    expect(getRegExp('한', { ignoreSpace: false }).source).toBe('(한|하[나-닣])');
+    expect(getRegExp('k', { ignoreSpace: false }).source).toBe('k');
+    expect(getRegExp('keyword', { ignoreSpace: false }).source).toBe('keyword');
   });
   test('ignoreSpace: true', () => {
     expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
+    expect(getRegExp('한', { ignoreSpace: true }).source).toBe('(한|하[나-닣])');
+    expect(getRegExp('k', { ignoreSpace: true }).source).toBe('k');
+    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
   });
 });
 

--- a/src/getRegExp.ts
+++ b/src/getRegExp.ts
@@ -79,11 +79,11 @@ const getRegExp = (() => {
           patterns.push(lastChar);
           // 종성이 초성으로 사용 가능한 경우
           if (INITIALS.includes(finale)) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
+            patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length)}${getInitialSearchRegExp(finale)}`);
           }
           // 종성이 복합 자음인 경우, 두 개의 자음으로 분리하여 각각 받침과 초성으로 사용
           if (MIXED[finale]) {
-          patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
+            patterns.push(`${String.fromCharCode(baseCode + medialOffset * FINALES.length + FINALES.join('').search(MIXED[finale][0]) + 1)}${getInitialSearchRegExp(MIXED[finale][1])}`);
           }
           break;
         }
@@ -113,13 +113,18 @@ const getRegExp = (() => {
           break;
       }
 
-    lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
+      lastCharPattern = patterns.length > 1 ? (nonCaptureGroup ? `(?:${patterns.join('|')})` : `(${patterns.join('|')})`) : patterns[0];
     }
     const glue = fuzzy ? FUZZY : ignoreSpace ? IGNORE_SPACE : '';
     const frontCharsPattern = initialSearch
-    ? frontChars.map((char) => (char.search(/[ㄱ-ㅎ]/) !== -1 ? getInitialSearchRegExp(char, true) : escapeRegExp(char))).join(glue)
+      ? frontChars.map((char) => (char.search(/[ㄱ-ㅎ]/) !== -1 ? getInitialSearchRegExp(char, true) : escapeRegExp(char))).join(glue)
       : escapeRegExp(frontChars.join(glue));
-    let pattern = (startsWith ? '^' : '') + frontCharsPattern + glue + lastCharPattern + (endsWith ? '$' : '');
+
+    const isNeedJointFrontAndLast = frontCharsPattern.trim() !== '' && lastCharPattern.trim() !== '';
+    const charsPattern = isNeedJointFrontAndLast ? `${frontCharsPattern}${glue}${lastCharPattern}` : `${frontCharsPattern}${lastCharPattern}`;
+
+    let pattern = (startsWith ? '^' : '') + charsPattern + (endsWith ? '$' : '');
+
     if (glue) {
       pattern = pattern.replace(RegExp(FUZZY, 'g'), '.*').replace(RegExp(IGNORE_SPACE, 'g'), '\\s*');
     }


### PR DESCRIPTION
- https://github.com/bluewings/korean-regexp/pull/10 여기서 수정했던것을 통합해서 반영합니다.

# 영문인 경우에 생겼던 문제
##  AS-IS
- 마지막 문자에도 \\s* 가 들어감
- `test k eyw ord    ` 라고 입력 되었을 때에 `k eyw ord` 만 잡고 싶은데 `k eyw ord    `까지 잡힘
```
test('ignoreSpace: true', () => {
  expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d\\s*');
});
```

##  TO-BE
- 한글인 경우에는 마지막에 \\s* 들어가지 않아서 이를 통일하도록 함
```
test('ignoreSpace: true', () => {
  expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
});
```

# 한글이 한글자 였을때 생겼던 문제
##  AS-IS
- 한글자 한글인 경우 앞에 \\s* 가 들어감
- `깃헙 과 깃랩` 이라고 입력 되었을 때에 `과` 만 잡고 싶은데 ` 과` 까지 잡힘

```
test('ignoreSpace: true', () => {
  expect(getRegExp('한', { ignoreSpace: true }).source).toBe('\\s*(한|하[나-닣])');
});
```

##  TO-BE
- 영문인 경우에는 한글자여도 앞에 \\s* 가 들어가지 않아서 이를 통일하도록 함
```
  test('ignoreSpace: true', () => {
   expect(getRegExp('한', { ignoreSpace: true }).source).toBe('(한|하[나-닣])');
  });
```

# 결론
- ignoreSpace 가 true 인 경우 글자사이에 간격이 없을 때에는 ignoreSpace 가 false 인 경우와 동일하게 동작해야하지 않을까요?

## AS-IS
```
describe('options.ignoreSpace', () => {
  test('ignoreSpace: false (default)', () => {
    expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
    expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
    expect(getRegExp('한', { ignoreSpace: false }).source).toBe('(한|하[나-닣])');
    expect(getRegExp('k', { ignoreSpace: false }).source).toBe('k');
    expect(getRegExp('keyword', { ignoreSpace: false }).source).toBe('keyword');
  });
  test('ignoreSpace: true', () => {
    expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
    // 여기를 주목해주세요.
    expect(getRegExp('한', { ignoreSpace: true }).source).toBe('\\s*(한|하[나-닣])');
    expect(getRegExp('k', { ignoreSpace: true }).source).toBe('k\\s*');
    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d\\s*');
  });
});
```

## TO-BE
```
describe('options.ignoreSpace', () => {
  test('ignoreSpace: false (default)', () => {
    expect(getRegExp('한글날').source).toBe(getRegExp('한글날', { ignoreSpace: false }).source);
    expect(getRegExp('한글날', { ignoreSpace: false }).source).toBe('한글(날|나[라-맇])');
    expect(getRegExp('한', { ignoreSpace: false }).source).toBe('(한|하[나-닣])');
    expect(getRegExp('k', { ignoreSpace: false }).source).toBe('k');
    expect(getRegExp('keyword', { ignoreSpace: false }).source).toBe('keyword');
  });
  test('ignoreSpace: true', () => {
    expect(getRegExp('한글날', { ignoreSpace: true }).source).toBe('한\\s*글\\s*(날|나[라-맇])');
    // 여기를 주목해주세요.
    expect(getRegExp('한', { ignoreSpace: true }).source).toBe('(한|하[나-닣])');
    expect(getRegExp('k', { ignoreSpace: true }).source).toBe('k');
    expect(getRegExp('keyword', { ignoreSpace: true }).source).toBe('k\\s*e\\s*y\\s*w\\s*o\\s*r\\s*d');
  });
});
```
